### PR TITLE
 Open file with utf-8 encoding

### DIFF
--- a/analyze_inspections.py
+++ b/analyze_inspections.py
@@ -2,6 +2,7 @@
 
 import argparse
 import functools
+import io
 import json
 import os
 import re
@@ -62,7 +63,7 @@ def assert_200_response(res, msg):
 
 def analyze_file(path):
     diagnostics = []
-    with open(path) as fin:
+    with io.open(path, encoding="utf-8") as fin:
         text = fin.read()
     text = text.replace('<?xml version="1.0" encoding="UTF-8"?>', "")
     text = text.replace("file://$PROJECT_DIR$/", "")


### PR DESCRIPTION
This change is needed as the Intellij update to 2020.3 resulted in UnicodeDecodeError.